### PR TITLE
Change wording of merchant method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
     .limit(5)
   end
 
-  def all_orders
+  def pending_orders
     Order.joins(:items).where("items.user_id =#{id} and orders.status =0").distinct
   end
 

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -7,7 +7,7 @@
   <%= current_user.zip%>
 </div>
 <div id="order-info">
-  <%current_user.all_orders.each do |order| %>
+  <%current_user.pending_orders.each do |order| %>
 
     <%=link_to order.id, merchant_orders_path(order)%>
     <p><%= order.created_at.strftime("%B %d, %Y")%></p>

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Merchant Show page' do
-
   describe 'when I visit my dashboard' do
 
     before :each do
@@ -49,7 +48,7 @@ RSpec.describe 'Merchant Show page' do
     end
 
 
-    it 'I see a list of orders and their information' do
+    it 'I see a list of pending orders and their information' do
 
       within '#order-info' do
         expect(page).to have_link(@o1.id.to_s)
@@ -69,9 +68,7 @@ RSpec.describe 'Merchant Show page' do
         expect(page).to have_content(@o1.items_total_value.to_f)
         expect(page).to have_content(@o2.items_total_value.to_f)
         expect(page).to have_content(@o3.items_total_value.to_f)
-
       end
     end
-
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe User, type: :model do
     end
 
     it '.all_orders' do
-      expect(@user.all_orders).to eq([@order_2])
+      expect(@user.pending_orders).to eq([@order_2])
     end
 
 


### PR DESCRIPTION
Changes wording on the User model. Previously it said #all_orders which was misleading as the method only returned pending orders for that merchant.